### PR TITLE
fix key length for inventory bootstrap

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ distributions {
 }
 
 task generateVersionText()  {
-    new File("src/main/resources/soracom-krypton-version").text = """Version: $version"""
+    new File(projectDir, "src/main/resources/soracom-krypton-version").text = """Version: $version"""
 }
 
 task sourceJar(type: Jar) {

--- a/src/main/java/io/soracom/krypton/SORACOMKryptonClient.java
+++ b/src/main/java/io/soracom/krypton/SORACOMKryptonClient.java
@@ -82,7 +82,7 @@ public class SORACOMKryptonClient {
 		request.requestParameters = params;
 		request.apiEndpointUrl = ProvisioningApiEndpoint
 				.bootstrapInventoryDevice(kryptonClientConfig.getApiEndpointUrl());
-
+		kryptonClientConfig.getEndorseClientConfig().setKeyLength(16);
 		ProvisioningBean invokeProvisioingApiResult = invokeProvisioningApi(request, true);
 		BootstrapInventoryDeviceResult result = Utilities.fromJson(
 				invokeProvisioingApiResult.getServiceProviderResponse(), BootstrapInventoryDeviceResult.class);


### PR DESCRIPTION
This patch corrects a wrong assumption that the key length must be 32 for all krypton operations. LwM2M uses DTLS protocol which expects a 128-bit Pre-Shared Key.